### PR TITLE
feat(dashboard): playbook to install required tools.

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,233 @@
+<!--
+ SPDX-License-Identifier: EPL-2.0
+ SPDX-FileCopyrightText: 2025 Siemens AG
+-->
+# SW360 Dashboard Ansible Automation
+
+This Ansible playbook automates the installation and configuration of the SW360 Dashboard infrastructure components as described in the main README.md.
+
+## Overview
+
+The playbook automates the following three main steps from the README:
+
+1. **Install Prometheus** - Downloads, installs, and configures Prometheus with systemd service
+2. **Install Prometheus Pushgateway** - Downloads, installs, and configures Pushgateway with systemd service  
+3. **Install Grafana** - Installs Grafana from the official repository and configures it
+
+## Prerequisites
+
+### System Requirements
+- Ubuntu/Debian-based system
+- Root/sudo access
+- Internet connectivity for downloading packages
+
+### Install Ansible
+```bash
+# On Ubuntu/Debian
+sudo apt update
+sudo apt install ansible
+
+# On CentOS/RHEL
+sudo yum install ansible
+# or
+sudo dnf install ansible
+
+# Verify installation
+ansible --version
+```
+
+## Directory Structure
+
+```
+ansible/
+├── playbook.yml           # Main Ansible playbook
+├── templates/             # Jinja2 templates (if any)
+└── README.md             # This file
+```
+
+## Configuration
+
+### Variables
+
+The playbook uses the following variables (defined in `vars` section):
+
+```yaml
+# Software versions
+prometheus_version: "2.47.2"
+pushgateway_version: "1.6.2"
+
+# Installation paths
+install_dir: "/opt"
+user: "username"        # Replace with your actual username
+group: "groupname"      # Replace with your actual group name
+```
+
+**Important:** You must update the `user` and `group` variables in the playbook before running it.
+
+### Customization
+
+You can customize the installation by modifying the variables in the playbook:
+
+```yaml
+vars:
+  prometheus_version: "2.47.2"      # Change Prometheus version
+  pushgateway_version: "1.6.2"      # Change Pushgateway version
+  install_dir: "/opt"                # Change installation directory
+  user: "username"                   # Change service user (REQUIRED)
+  group: "groupname"                 # Change service group (REQUIRED)
+```
+
+**Note:** The `user` and `group` variables are placeholders and must be updated with actual values before running the playbook.
+
+## Usage
+
+### Prerequisites Configuration
+
+**Before running the playbook, you MUST:**
+
+1. **Update the inventory file** (`inventory`) with your actual server details
+2. **Update the playbook variables** - Replace `username` and `groupname` with actual values:
+   ```yaml
+   user: "your_actual_username"
+   group: "your_actual_groupname"
+   ```
+3. **Update the hosts target** - Replace `foss360` with your actual inventory group name
+
+### Basic Usage
+
+1. **Navigate to the ansible directory:**
+   ```bash
+   cd /path/to/dashboard/ansible
+   ```
+
+2. **Run the playbook:**
+   ```bash
+   ansible-playbook playbook.yml
+   ```
+
+3. **Run with verbose output:**
+   ```bash
+   ansible-playbook playbook.yml -v
+   ```
+
+#### Run with different inventory
+```bash
+ansible-playbook -i inventory.yml playbook.yml
+```
+
+## What the Playbook Does
+
+### Step 1: Install Prometheus
+- Downloads Prometheus v2.47.2 from GitHub releases
+- Extracts and installs to `/opt/prometheus/`
+- Creates systemd service file with specified user/group
+- Enables and starts Prometheus service
+- Configures retention time to 7 days
+
+### Step 2: Install Prometheus Pushgateway
+- Downloads Pushgateway v1.6.2 from GitHub releases
+- Extracts and installs to `/opt/pushgateway/`
+- Creates systemd service file with specified user/group
+- Enables and starts Pushgateway service
+- Configures Prometheus to scrape Pushgateway metrics
+
+### Step 3: Install Grafana
+- Adds official Grafana APT repository
+- Installs Grafana package
+- Configures Grafana to use port 3001
+- Enables and starts Grafana service
+
+### Additional Tasks
+- Installs Poetry for Python dependency management
+- Creates necessary directories with proper permissions
+- Configures systemd services with proper user/group ownership
+- Provides detailed completion summary with next steps
+
+## Service Information
+
+After successful execution, the following services will be running:
+
+| Service | Port | URL | Description |
+|---------|------|-----|-------------|
+| Prometheus | 9090 | http://localhost:9090 | Metrics collection and storage |
+| Pushgateway | 9091 | http://localhost:9091 | Metrics pushing gateway |
+| Grafana | 3001 | http://localhost:3001 | Dashboard and visualization |
+
+## Post-Installation Steps
+
+1. **Configure Grafana Datasource:**
+   - Open http://localhost:3001
+   - Login with admin/admin
+   - Add Prometheus datasource: http://localhost:9090
+
+2. **Import Dashboards:**
+   - Navigate to Dashboards → Import
+   - Upload JSON files from `grafana/dashboards/` directory
+
+3. **Install SW360 Dashboard Package:**
+   - Clone this repository to your desired location
+   - Navigate to the repository: `cd /path/to/sw360-dashboard`
+   - Install dependencies: `poetry install`
+   - Generate group files: `poetry run generate-groups <business_units>`
+   - Configure environment: `cp .env.example .env` and edit with your SW360 credentials
+
+4. **Setup Cron Job:**
+   - Configure automated data collection
+   - Setup log rotation
+
+## Troubleshooting
+
+### Service Management
+
+```bash
+# Check service status
+sudo systemctl status prometheus
+sudo systemctl status pushgateway
+sudo systemctl status grafana-server
+
+# Start/stop services
+sudo systemctl start prometheus
+sudo systemctl stop prometheus
+sudo systemctl restart prometheus
+
+# Enable/disable services
+sudo systemctl enable prometheus
+sudo systemctl disable prometheus
+
+# View logs
+sudo journalctl -u prometheus -f
+sudo journalctl -u pushgateway -f
+sudo journalctl -u grafana-server -f
+```
+
+### Configuration Files
+
+| Component | Configuration File | Service File |
+|-----------|-------------------|--------------|
+| Prometheus | `/opt/prometheus/prometheus.yml` | `/etc/systemd/system/prometheus.service` |
+| Pushgateway | N/A | `/etc/systemd/system/pushgateway.service` |
+| Grafana | `/etc/grafana/grafana.ini` | `/etc/systemd/system/grafana-server.service` |
+
+## Verification
+
+### Health Checks
+```bash
+# Check if services are responding
+curl http://localhost:9090/-/healthy
+curl http://localhost:9091/-/healthy
+curl http://localhost:3001/api/health
+
+# Check Prometheus targets
+curl http://localhost:9090/api/v1/targets
+
+# Check Pushgateway metrics
+curl http://localhost:9091/metrics
+```
+
+### Log Files
+```bash
+# View service logs
+sudo journalctl -u prometheus --since "1 hour ago"
+sudo journalctl -u pushgateway --since "1 hour ago"
+sudo journalctl -u grafana-server --since "1 hour ago"
+```

--- a/ansible/playbook.yml
+++ b/ansible/playbook.yml
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: EPL-2.0
+# Copyright Siemens AG, 2025. Part of the SW360 Portal Project.
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+---
+- name: SW360 Dashboard Infrastructure Setup
+  hosts: foss360  # Replace with your actual group name present in your inventory
+  become: yes
+  vars:
+    # Software versions
+    prometheus_version: "2.47.2"
+    pushgateway_version: "1.6.2"
+    
+    # Configuration
+    install_dir: "/opt"
+    user: "username"  # Replace with the appropriate username
+    group: "groupname"  # Replace with the appropriate group name
+    
+  tasks:
+    # Prerequisites
+    - name: Update package cache
+      apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    # Step 0: Install Poetry and SW360 Dashboard dependencies
+    - name: Install Poetry
+      shell: |
+        curl -sSL https://install.python-poetry.org | python3 -
+      args:
+        creates: "/home/{{ user }}/.local/bin/poetry"
+      become_user: "{{ user }}"
+
+    - name: Add Poetry to PATH in .bashrc
+      lineinfile:
+        path: "/home/{{ user }}/.bashrc"
+        line: 'export PATH="$HOME/.local/bin:$PATH"'
+        create: yes
+      become_user: "{{ user }}"
+
+    - name: Display Poetry installation completion
+      debug:
+        msg: |
+          ✅ Poetry has been successfully installed for user {{ user }}
+          
+          To set up the SW360 Dashboard, please:
+          1. Clone the SW360 dashboard repository to your desired location
+          2. Navigate to the cloned directory
+          3. Run: poetry install
+          4. Run: poetry run generate-groups <your_business_units>
+          5. Create .env from .env.example and configure it
+          
+          Example:
+          git clone <repository_url> /path/to/sw360-dashboard
+          cd /path/to/sw360-dashboard
+          poetry install
+          poetry run generate-groups DEPT DEPT2
+          cp .env.example .env
+          # Edit .env with your SW360 configuration
+
+    # Step 1: Install Prometheus
+
+    - name: Download and extract Prometheus directly to installation directory
+      unarchive:
+        src: "https://github.com/prometheus/prometheus/releases/download/v{{ prometheus_version }}/prometheus-{{ prometheus_version }}.linux-amd64.tar.gz"
+        dest: "{{ install_dir }}"
+        remote_src: yes
+        owner: "{{ user }}"
+        group: "{{ group }}"
+        creates: "{{ install_dir }}/prometheus-{{ prometheus_version }}.linux-amd64"
+
+    - name: Create symlink for Prometheus
+      file:
+        src: "{{ install_dir }}/prometheus-{{ prometheus_version }}.linux-amd64"
+        dest: "{{ install_dir }}/prometheus"
+        state: link
+        owner: "{{ user }}"
+        group: "{{ group }}"
+
+    - name: Create Prometheus systemd service file
+      template:
+        src: prometheus.service.j2
+        dest: /etc/systemd/system/prometheus.service
+        mode: '0644'
+      notify: restart prometheus
+
+    - name: Enable and start Prometheus service
+      systemd:
+        name: prometheus
+        enabled: yes
+        state: started
+        daemon_reload: yes
+
+    # Step 2: Install Prometheus Pushgateway
+
+    - name: Download and extract Pushgateway directly to installation directory
+      unarchive:
+        src: "https://github.com/prometheus/pushgateway/releases/download/v{{ pushgateway_version }}/pushgateway-{{ pushgateway_version }}.linux-amd64.tar.gz"
+        dest: "{{ install_dir }}"
+        remote_src: yes
+        owner: "{{ user }}"
+        group: "{{ group }}"
+        creates: "{{ install_dir }}/pushgateway-{{ pushgateway_version }}.linux-amd64"
+
+    - name: Create symlink for Pushgateway
+      file:
+        src: "{{ install_dir }}/pushgateway-{{ pushgateway_version }}.linux-amd64"
+        dest: "{{ install_dir }}/pushgateway"
+        state: link
+        owner: "{{ user }}"
+        group: "{{ group }}"
+
+    - name: Create Pushgateway systemd service file
+      template:
+        src: pushgateway.service.j2
+        dest: /etc/systemd/system/pushgateway.service
+        mode: '0644'
+      notify: restart pushgateway
+
+    - name: Enable and start Pushgateway service
+      systemd:
+        name: pushgateway
+        enabled: yes
+        state: started
+        daemon_reload: yes
+
+    - name: Remove duplicate scrape_configs section if it exists
+      blockinfile:
+        path: "{{ install_dir }}/prometheus/prometheus.yml"
+        marker: "# {mark} ANSIBLE MANAGED BLOCK - Pushgateway"
+        state: absent
+
+    - name: Configure Prometheus to scrape Pushgateway
+      blockinfile:
+        path: "{{ install_dir }}/prometheus/prometheus.yml"
+        block: |
+          
+            # Pushgateway job configuration
+            - job_name: 'pushgateway'
+              static_configs:
+                - targets: ['localhost:9091']
+        marker: "  # {mark} ANSIBLE MANAGED BLOCK - Pushgateway"
+        backup: yes
+        insertafter: 'targets: \["localhost:9090"\]'
+      notify: restart prometheus
+
+    # Step 3: Install Grafana Community Edition (Open Source)
+    - name: Add Grafana GPG key
+      apt_key:
+        url: https://apt.grafana.com/gpg.key
+        state: present
+
+    - name: Add Grafana repository
+      apt_repository:
+        repo: "deb https://apt.grafana.com stable main"
+        state: present
+
+    - name: Install Grafana Community Edition
+      apt:
+        name: grafana
+        state: present
+        update_cache: yes
+
+    - name: Configure Grafana to use port 3001
+      lineinfile:
+        path: /etc/grafana/grafana.ini
+        regexp: '^;?http_port'
+        line: 'http_port = 3001'
+        backup: yes
+      notify: restart grafana
+
+    - name: Enable and start Grafana service
+      systemd:
+        name: grafana-server
+        enabled: yes
+        state: started
+
+    # Cleanup - No temporary files to clean up since we extract directly to destination
+
+  handlers:
+    - name: restart prometheus
+      systemd:
+        name: prometheus
+        state: restarted
+        daemon_reload: yes
+
+    - name: restart pushgateway
+      systemd:
+        name: pushgateway
+        state: restarted
+        daemon_reload: yes
+
+    - name: restart grafana
+      systemd:
+        name: grafana-server
+        state: restarted
+
+  post_tasks:
+    - name: Display setup completion message
+      debug:
+        msg: |
+          ========================================
+          SW360 Dashboard Infrastructure Complete!
+          ========================================
+          
+          Services installed and running:
+          ✓ Prometheus: http://localhost:9090
+          ✓ Pushgateway: http://localhost:9091  
+          ✓ Grafana: http://localhost:3001
+          ✓ Poetry: Installed for user {{ user }}
+          
+          Default Grafana login:
+          - Username: admin
+          - Password: admin
+          
+          Next steps:
+          1. Clone the SW360 dashboard repository to your preferred location
+          2. Navigate to the repository and run: poetry install
+          3. Generate group files: poetry run generate-groups <business_units>
+          4. Configure .env file with your SW360 credentials
+          5. Configure Grafana datasource to point to http://localhost:9090
+          6. Import dashboards from grafana/dashboards/ directory
+          7. Test SW360 exporter: poetry run sw360-exporter <business_units>
+          8. Setup cron job for automated metrics collection
+          
+          Service management commands:
+          - sudo systemctl status prometheus
+          - sudo systemctl status pushgateway
+          - sudo systemctl status grafana-server
+          
+          Poetry is available for user {{ user }} - reload shell or run:
+          export PATH="$HOME/.local/bin:$PATH"

--- a/ansible/templates/prometheus.service.j2
+++ b/ansible/templates/prometheus.service.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=Prometheus server
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+User={{ user }}
+Group={{ group }}
+Type=simple
+Restart=always
+WorkingDirectory={{ install_dir }}/prometheus
+RuntimeDirectory=prometheus
+RuntimeDirectoryMode=0750
+ExecStart={{ install_dir }}/prometheus/prometheus \
+    --config.file={{ install_dir }}/prometheus/prometheus.yml \
+    --storage.tsdb.retention.time=7d
+
+LimitNOFILE=10000
+TimeoutStopSec=20
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/templates/pushgateway.service.j2
+++ b/ansible/templates/pushgateway.service.j2
@@ -1,0 +1,20 @@
+[Unit]
+Description=Prometheus Pushgateway server
+Wants=network-online.target
+After=prometheus.service
+
+[Service]
+User={{ user }}
+Group={{ group }}
+Type=simple
+Restart=always
+WorkingDirectory={{ install_dir }}/pushgateway
+RuntimeDirectory=pushgateway
+RuntimeDirectoryMode=0750
+ExecStart={{ install_dir }}/pushgateway/pushgateway
+
+LimitNOFILE=10000
+TimeoutStopSec=20
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
The playbook automates the following three main steps from the README:

Install Prometheus - Downloads, installs, and configures Prometheus with systemd service
Install Prometheus Pushgateway - Downloads, installs, and configures Pushgateway with systemd service
Install Grafana - Installs Grafana from the official repository and configures it
Additional Tasks

Installs Poetry for Python dependency management